### PR TITLE
bump mite schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] 13-02-2025
+
+### Changed
+
+- Bumped `mite_schema` version to `1.7.1`
+
 ## [1.4.0] 13-02-2025
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mite_extras"
-version = "1.4.0"
+version = "1.4.1"
 description = "Parsing, conversion, and validation functionality for Minimum Information about a Tailoring Enzyme (MITE) files."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -29,7 +29,7 @@ dependencies = [
     "argparse~=1.4",
     "coloredlogs~=15.0",
     "jsonschema~=4.23",
-    "mite-schema==1.7.0",
+    "mite-schema==1.7.1",
     "pydantic~=2.8",
     "rdkit==2024.3.6",
     "requests~=2.32",


### PR DESCRIPTION
## [1.4.1] 13-02-2025

### Changed

- Bumped `mite_schema` version to `1.7.1`