### PR TITLE
Updated mite_schema dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] 29-08-2025
+
+### Changed
+
+- Unpinned version of dependency of `mite_schema` to facilitate maintenance (should always pull newest release)
+
 ## [1.6.0] 28-08-2025
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mite_extras"
-version = "1.6.0"
+version = "1.6.1"
 description = "Parsing, conversion, and validation functionality for Minimum Information about a Tailoring Enzyme (MITE) files."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,7 +26,7 @@ dependencies = [
     "coloredlogs~=15.0",
     "json-repair~=0.46",
     "jsonschema~=4.23",
-    "mite-schema==1.8.0",
+    "mite-schema",
     "pydantic~=2.8",
     "rdkit==2024.3.6",
     "requests~=2.32",


### PR DESCRIPTION
## [1.6.1] 29-08-2025

### Changed

- Unpinned version of dependency of `mite_schema` to facilitate maintenance (should always pull newest release)